### PR TITLE
Ettus

### DIFF
--- a/JavaGUI/makefile
+++ b/JavaGUI/makefile
@@ -91,7 +91,7 @@ else ifeq ($(OSNAME), LINUX)
 PLUGINS += TSDRPlugin_librtlsdr
 PLUGINS += TSDRPlugin_Airspy
 PLUGINS += TSDRPlugin_HackRF
-#PLUGINS += TSDRPlugin_UHD
+PLUGINS += TSDRPlugin_UHD
 else ifeq ($(OSNAME), MAC)
 PLUGINS += TSDRPlugin_UHD
 endif

--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ Ettus
 ------
 Check out the Ettus branch. It provides rudimentary native support update to Ettus SDR in Linux.
 
+
+##### Install tools, compilers and libraries
+```
+sudo add-apt-repository ppa:ettusresearch/uhd
+sudo apt-get update
+sudo apt-get install libuhd-dev libuhd003 uhd-host
+```
+
 ##### Clone git and build
 ```
 mkdir ~/development

--- a/TSDRPlugin_UHD/src/TSDRPlugin_UHD.cpp
+++ b/TSDRPlugin_UHD/src/TSDRPlugin_UHD.cpp
@@ -14,7 +14,11 @@
 #include <stdlib.h>
 #include <string.h>
 
+/*
 #include <uhd/utils/thread_priority.hpp>
+*/
+
+#include <uhd/utils/thread.hpp>
 #include <uhd/utils/safe_main.hpp>
 #include <uhd/usrp/multi_usrp.hpp>
 #include <uhd/transport/udp_simple.hpp>
@@ -332,7 +336,10 @@ EXTERNC TSDRPLUGIN_API int __stdcall tsdrplugin_readasync(tsdrplugin_readasync_f
 		// flush usrpbuffer
 	    while(rx_stream->recv(
 	        buff, samples_per_api_read, md,
-	        uhd::device::RECV_MODE_ONE_PACKET
+	        //uhd::device::RECV_MODE_ONE_PACKET
+		// Note that RECV_MODE_ONE_PACKET=1 is deprecated and no longer defined in the new ettus header for uhd::device
+		// Hence use the fundamental boolean value (true)
+		true
 	    )){
 	        /* NOP */
 	    };


### PR DESCRIPTION
1. Update makefile to include TSDRPlugin_UHD for WINDOWS build

2. Update TSDRPlugin_UHD to use the new thread.hpp headers from Ettus
<uhd/utils/thread.hpp>

3. Update TSDRPlugin_UHD to remove use of deprecated declaration RECV_MODE_ONE_PACKET (which has value 1). Boolean value (true) is used instead